### PR TITLE
Add run_metrics flag to imageless pipeline

### DIFF
--- a/tools/run_danesfield_imageless.py
+++ b/tools/run_danesfield_imageless.py
@@ -192,6 +192,7 @@ def main(args):
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('cfg', help='path/to/configuration.ini file')
     parser.add_argument("--vissat", help="run Vissat stereo pipeline", action="store_true")
+    parser.add_argument("--run_metrics", help="run metrics", action="store_true")
     args = parser.parse_args(args)
 
 ### read configuration ini file
@@ -403,18 +404,19 @@ def main(args):
     # Run metrics
     #############################################
 
-    run_metrics_outdir = os.path.join(working_dir, 'run_metrics')
-    cmd_args = py_cmd(relative_tool_path('run_metrics.py'))
-    cmd_args += [
-        '--output-dir', run_metrics_outdir,
-        '--ref-dir', config['metrics']['ref_data_dir'],
-        '--ref-prefix', config['metrics']['ref_data_prefix'],
-        '--dsm', output_dsm,
-        '--cls', output_cls,
-        '--dtm', dtm_file]
-    run_step(run_metrics_outdir,
-        'run-metrics',
-             cmd_args)
+    if args.run_metrics:
+        run_metrics_outdir = os.path.join(working_dir, 'run_metrics')
+        cmd_args = py_cmd(relative_tool_path('run_metrics.py'))
+        cmd_args += [
+            '--output-dir', run_metrics_outdir,
+            '--ref-dir', config['metrics']['ref_data_dir'],
+            '--ref-prefix', config['metrics']['ref_data_prefix'],
+            '--dsm', output_dsm,
+            '--cls', output_cls,
+            '--dtm', dtm_file]
+        run_step(run_metrics_outdir,
+            'run-metrics',
+                cmd_args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds the same `run_metrics` flag that is present in `run_danesfield.py` to the imageless pipeline.