### PR TITLE
Bug Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,6 +199,7 @@ RUN ["/bin/bash", "-c", "source /opt/conda/etc/profile.d/conda.sh && \
 RUN ${CONDA} install -n core3d -c local ${CHANNELS} laspy
 RUN ${CONDA} install -n core3d -c local ${CHANNELS} pubgeo-tools
 RUN ${CONDA} install -n core3d -c local ${CHANNELS} pubgeo-core3d-metrics
+RUN ${CONDA} install -n core3d -c kitware-danesfield ${CHANNELS} vtk=v9.1
 RUN ${CONDA} install -n texture -c kitware-danesfield ${CHANNELS} vtk=v9.1
 RUN ${CONDA} install -n texture -c local ${CHANNELS} kwiver vtk=v9.1 texture-atlas gdal scipy pyproj imageio python-pdal
 

--- a/tools/compute_vndvi.py
+++ b/tools/compute_vndvi.py
@@ -46,11 +46,12 @@ def main(argv):
     parser.add_argument('image', help='path/to/DSM.tif')
     parser.add_argument('input', help='path/to/colored/point/cloud.las')
     parser.add_argument('output', help='path/to/NDVI.tif')
+    parser.add_argument('--gsd', help='ground sample distance')
     args = parser.parse_args(argv)
 
     imgFN = args.image
     path2output = os.path.dirname(args.output)
-    computeRGB([path2output, '--source_points', args.input])
+    computeRGB([path2output, '--source_points', args.input, '--gsd', args.gsd])
     vndvi = vNDVI(path2output)
     gdal_save(vndvi, gdal_open(imgFN), args.output,
               gdal.GDT_Float32,

--- a/tools/compute_vndvi.py
+++ b/tools/compute_vndvi.py
@@ -46,7 +46,7 @@ def main(argv):
     parser.add_argument('image', help='path/to/DSM.tif')
     parser.add_argument('input', help='path/to/colored/point/cloud.las')
     parser.add_argument('output', help='path/to/NDVI.tif')
-    parser.add_argument('--gsd', help='ground sample distance')
+    parser.add_argument('gsd', help='ground sample distance')
     args = parser.parse_args(argv)
 
     imgFN = args.image

--- a/tools/get_road_vector.py
+++ b/tools/get_road_vector.py
@@ -114,7 +114,7 @@ def main(args):
     geojson_output_filepath = os.path.join(
         args.output_dir, "{}.geojson".format(args.output_prefix))
     # Manually tweak GeoJSON to fit expected format
-    with open(geojson_preform_output_filepath, 'r') as f:
+    with open(geojson_preform_output_filepath, 'r', encoding='utf-8') as f:
         json_data = json.load(f)
 
     json_data["features"] = [feature_map(f) for f in json_data["features"]]

--- a/tools/run_danesfield.py
+++ b/tools/run_danesfield.py
@@ -475,7 +475,7 @@ def main(args):
         ndvi_outdir = os.path.join(working_dir, 'compute-ndvi')
         ndvi_output_fpath = os.path.join(ndvi_outdir, 'vndvi.tif')
         cmd_args = py_cmd(relative_tool_path('compute_vndvi.py'))
-        cmd_args += [dsm_file, p3d_file, ndvi_output_fpath]
+        cmd_args += [dsm_file, p3d_file, ndvi_output_fpath, str(gsd)]
 
         NDVI = run_step(ndvi_outdir,
                  'compute-vndvi',

--- a/tools/run_danesfield.py
+++ b/tools/run_danesfield.py
@@ -592,19 +592,20 @@ def main(args):
     #############################################
     texture_mapping_outdir = ""
     if not args.image:
-        if args.gpm:
-            gpm_meta_outdir = os.path.join(working_dir, 'gpm-data')
-            meta_file = os.path.join(gpm_meta_outdir, 'gpm_metadata.json')
-            cmd_args = py_cmd(relative_tool_path('extract_gpm_metadata.py'))
-            cmd_args += ['--output_file', meta_file, p3d_file]
-            run_step_switch_env('texture', gpm_meta_outdir, 'gpm-data', cmd_args)
-
+        if args.vNDVI:
             gpm_outdir = os.path.join(working_dir, 'gpm-texture-mapping')
-            cmd_args = py_cmd(relative_tool_path('texture_map_point_cloud.py'))
-            cmd_args += ['--output_dir', gpm_outdir, '--gpm_json', meta_file,
-                         roof_geon_extraction_outdir, p3d_file]
-            run_step_switch_env('texture', gpm_outdir, 'gpm-texture-mapping', cmd_args)
+            cmd_args_tm = py_cmd(relative_tool_path('texture_map_point_cloud.py'))  
 
+            if args.gpm:
+                gpm_meta_outdir = os.path.join(working_dir, 'gpm-data')
+                meta_file = os.path.join(gpm_meta_outdir, 'gpm_metadata.json')
+                cmd_args = py_cmd(relative_tool_path('extract_gpm_metadata.py'))
+                cmd_args += ['--output_file', meta_file, p3d_file]
+                run_step_switch_env('texture', gpm_meta_outdir, 'gpm-data', cmd_args)
+                cm_args_tm += ['--gpm_json', meta_file]
+
+            cmd_args_tm += ['--output_dir', gpm_outdir, roof_geon_extraction_outdir, p3d_file]
+            run_step_switch_env('texture', gpm_outdir, 'gpm-texture-mapping', cmd_args_tm)
         else:
             occlusion_mesh = os.path.join(roof_geon_extraction_outdir, 'occlusion_mesh.obj')
     else:


### PR DESCRIPTION
Fixes:
vNDVI step uses GSD from config file instead of the default .25
Texture mapping with the point cloud will run with the vNDVI flag even if there's no gpm flag
road vector step will now work for locations outside the US, i.e. in places where street names have non-ASCII characters