### PR TITLE
Switched to more efficient KDTree implementation in scipy

### DIFF
--- a/tools/texture_map_point_cloud.py
+++ b/tools/texture_map_point_cloud.py
@@ -21,7 +21,8 @@ import pdal
 import sys
 
 from pathlib import Path
-from scipy.spatial import KDTree
+# If scipy upgraded to >= 1.6 then return to KDTree
+from scipy.spatial import cKDTree as KDTree
 from time import time
 
 from danesfield.gpm import GPM


### PR DESCRIPTION
Switched to the cKDTree implementation of the kdtree algorithm in scipy since it performs better. This is only
relevent to scipy versions less than 1.6, so if scipy is upgraded this change will not be necessary.